### PR TITLE
Migrate local study storage to SQLite

### DIFF
--- a/app.json
+++ b/app.json
@@ -12,7 +12,9 @@
       "supportsTablet": true,
       "bundleIdentifier": "com.kakustudy.kakustudy",
       "infoPlist": {
-        "UIBackgroundModes": ["remote-notification"]
+        "UIBackgroundModes": [
+          "remote-notification"
+        ]
       }
     },
     "android": {
@@ -37,7 +39,8 @@
         }
       ],
       "expo-secure-store",
-      "expo-video"
+      "expo-video",
+      "expo-sqlite"
     ],
     "experiments": {
       "typedRoutes": true

--- a/app/(tabs)/study/[id].tsx
+++ b/app/(tabs)/study/[id].tsx
@@ -9,10 +9,9 @@ import {
   ActivityIndicator,
 } from "react-native";
 import { useLocalSearchParams } from "expo-router";
-import { NON_CUSTOMER_FLASH_CARD_KEY } from "@/constants";
 import { TImage } from "@/types";
 import MaskedBlocks from "@/components/organisms/study/MaskedBlocks";
-import { getValueFor } from "@/lib/storage";
+import { getStudyItemById } from "@/lib/study-items";
 
 export default function StudyDetailScreen() {
   const local = useLocalSearchParams();
@@ -27,13 +26,13 @@ export default function StudyDetailScreen() {
 
   useEffect(() => {
     const fetchData = async () => {
-      const storedData = await getValueFor(NON_CUSTOMER_FLASH_CARD_KEY);
-      const images: TImage[] = storedData ? JSON.parse(storedData) : [];
-      const image = images.find((img) => img.id === Number(studyId)) ?? {
-        id: 0,
-        uri: "",
-        masks: [],
-      };
+      const image = await getStudyItemById(Number(studyId));
+      if (!image) {
+        setImageData({ id: 0, uri: "", masks: [] });
+        setHiddenRects([]);
+        return;
+      }
+
       setImageData(image);
       setHiddenRects(Array(image.masks.length).fill(true));
     };

--- a/app/(tabs)/study/create.tsx
+++ b/app/(tabs)/study/create.tsx
@@ -9,14 +9,14 @@ import {
 } from "react-native";
 import ImageMaskDrawer from "@/components/organisms/study/ImageMaskDrawer";
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
-import { NON_CUSTOMER_FLASH_CARD_KEY } from "@/constants";
-import { getValueFor, saveToLocalStorage } from "@/lib/storage";
+import { saveStudyItem } from "@/lib/study-items";
 import { router } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
+import { RectMask } from "@/types";
 
 export default function CreateScreen() {
   const [selectedImage, setSelectedImage] = useState<string | null>(null);
-  const [maskedData, setMaskedData] = useState<any[]>([]);
+  const [maskedData, setMaskedData] = useState<RectMask[]>([]);
   // TODO: 会員: true。非会員: falseになるようにする
   const isRegisteredMember = true;
 
@@ -39,23 +39,17 @@ export default function CreateScreen() {
     if (!selectedImage) return;
 
     try {
-      // 既存データの取得
-      const storedData = await getValueFor(NON_CUSTOMER_FLASH_CARD_KEY);
-      let images = storedData ? JSON.parse(storedData) : [];
-
-      // 非会員は 1つだけ登録可能
-      if (!isRegisteredMember) {
-        images = [];
-      }
-
       const newImageData = {
         id: Date.now(),
         uri: selectedImage,
         masks: maskedData,
       };
 
-      images.push(newImageData);
-      saveToLocalStorage(NON_CUSTOMER_FLASH_CARD_KEY, JSON.stringify(images));
+      if (!isRegisteredMember) {
+        return;
+      }
+
+      await saveStudyItem(newImageData);
       setSelectedImage(null);
       setMaskedData([]);
       alert("画像を保存しました！");

--- a/app/(tabs)/study/index.tsx
+++ b/app/(tabs)/study/index.tsx
@@ -11,9 +11,8 @@ import {
   SafeAreaView,
 } from "react-native";
 import { Link, useFocusEffect, useRouter } from "expo-router";
-import { NON_CUSTOMER_FLASH_CARD_KEY } from "@/constants";
 import { TImage } from "@/types";
-import { getValueFor, saveToLocalStorage } from "@/lib/storage";
+import { deleteStudyItemById, listStudyItems } from "@/lib/study-items";
 import { Ionicons } from "@expo/vector-icons";
 
 export default function StudyListScreen() {
@@ -22,8 +21,7 @@ export default function StudyListScreen() {
   const router = useRouter(); // routerフックを使う
   const fetchImages = async () => {
     setIsLoading(true); // データ取得中の状態を管理
-    const storedData = await getValueFor(NON_CUSTOMER_FLASH_CARD_KEY);
-    const images = storedData ? JSON.parse(storedData) : [];
+    const images = await listStudyItems();
     setImageList(images);
     setIsLoading(false);
   };
@@ -32,10 +30,7 @@ export default function StudyListScreen() {
     const updatedImages = imageList.filter((item) => item.id !== id);
     setImageList(updatedImages); // JSスレッドで保持
     Alert.alert("削除しました");
-    await saveToLocalStorage(
-      NON_CUSTOMER_FLASH_CARD_KEY,
-      JSON.stringify(updatedImages)
-    ); // 永続化
+    await deleteStudyItemById(id);
   };
   // タブ遷移時にデータを取得する
   useFocusEffect(

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,6 +1,49 @@
+import { initializeDatabase } from "@/lib/study-items";
 import { Stack } from "expo-router";
+import { useEffect, useState } from "react";
+import { ActivityIndicator, StyleSheet, Text, View } from "react-native";
 
 export default function RootLayout() {
+  const [isReady, setIsReady] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    initializeDatabase()
+      .then(() => {
+        if (isMounted) {
+          setIsReady(true);
+        }
+      })
+      .catch((databaseError) => {
+        console.error(databaseError);
+        if (isMounted) {
+          setError("データベースの初期化に失敗しました");
+        }
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  if (error) {
+    return (
+      <View style={styles.centered}>
+        <Text>{error}</Text>
+      </View>
+    );
+  }
+
+  if (!isReady) {
+    return (
+      <View style={styles.centered}>
+        <ActivityIndicator size="large" color="#f57c00" />
+      </View>
+    );
+  }
+
   return (
     <Stack>
       <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
@@ -8,3 +51,12 @@ export default function RootLayout() {
     </Stack>
   );
 }
+
+const styles = StyleSheet.create({
+  centered: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "#fff",
+  },
+});

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -1,1 +1,3 @@
-export const NON_CUSTOMER_FLASH_CARD_KEY = "flash_card";
+export const LEGACY_FLASH_CARD_KEY = "flash_card";
+export const SQLITE_MIGRATION_KEY = "sqlite_migration_v1";
+export const SQLITE_DATABASE_NAME = "kaku-study.db";

--- a/docs/adr/0009-local-sqlite-migration.md
+++ b/docs/adr/0009-local-sqlite-migration.md
@@ -1,0 +1,38 @@
+# ADR 0009: Local SQLite Migration
+
+- Status: `Accepted`
+- Date: `2026-03-10`
+
+## Context
+
+現状のローカル保存は SecureStore に 1 件の JSON を丸ごと保存している。
+この構造では、オフラインファースト、再編集、段階的な同期、学習履歴の追加が難しい。
+一方で既存ユーザーの端末には SecureStore 上のデータが残っている可能性がある。
+
+## Decision
+
+- ローカルの正規ストアは `expo-sqlite` に移行する
+- データアクセスは repository 層に集約し、画面は SQL を持たない
+- app 起動時に SQLite を初期化する
+- 既存の SecureStore データは一度だけ SQLite に移行する
+- migration 成功後は legacy key を削除し、migration 完了フラグを残す
+- 画面側は `listStudyItems` `getStudyItemById` `saveStudyItem` `deleteStudyItemById` を使う
+
+## Rationale
+
+- 画面から storage 詳細を切り離せる
+- 今後の同期、学習履歴、entitlement cache を同じ DB に載せやすい
+- legacy data migration を app 起動時に吸収すれば、既存データを落とさずに移行できる
+
+## Consequences
+
+### Positive
+
+- オフライン保存の土台が ADR 0003 と一致する
+- 以後の API 実装や sync queue 実装が追加しやすくなる
+- 既存ユーザーのデータ継続性を確保できる
+
+### Negative
+
+- 起動時の初期化と migration 失敗ハンドリングが必要になる
+- schema 変更時に migration 運用が必要になる

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1,18 +1,13 @@
 import * as SecureStore from "expo-secure-store";
 
-export async function saveToLocalStorage(key: any, value: any) {
-  console.log("saveToLocalStorage", key + value);
+export async function setSecureValue(key: string, value: string) {
   await SecureStore.setItemAsync(key, value);
 }
 
-export async function getValueFor(key: any) {
-  console.log("=====key", key);
-  const result = await SecureStore.getItemAsync(key);
-  if (result) {
-    console.log("🔐 Here's your value 🔐 \n" + result);
-    return result;
-  } else {
-    console.log("No values stored under that key.");
-    return "";
-  }
+export async function getSecureValue(key: string) {
+  return (await SecureStore.getItemAsync(key)) ?? "";
+}
+
+export async function deleteSecureValue(key: string) {
+  await SecureStore.deleteItemAsync(key);
 }

--- a/lib/study-items.ts
+++ b/lib/study-items.ts
@@ -1,0 +1,224 @@
+import { LEGACY_FLASH_CARD_KEY, SQLITE_DATABASE_NAME, SQLITE_MIGRATION_KEY } from "@/constants";
+import { deleteSecureValue, getSecureValue, setSecureValue } from "@/lib/storage";
+import { TImage, TMask } from "@/types";
+import { openDatabaseAsync, SQLiteDatabase } from "expo-sqlite";
+
+type StudyItemRow = {
+  id: number;
+  uri: string;
+};
+
+type StudyMaskRow = TMask;
+
+let databasePromise: Promise<SQLiteDatabase> | null = null;
+
+function getDatabase() {
+  if (!databasePromise) {
+    databasePromise = initializeDatabaseInternal();
+  }
+
+  return databasePromise;
+}
+
+async function initializeDatabaseInternal() {
+  const database = await openDatabaseAsync(SQLITE_DATABASE_NAME);
+
+  await database.execAsync(`
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE IF NOT EXISTS study_items (
+      id INTEGER PRIMARY KEY NOT NULL,
+      uri TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      deleted_at TEXT
+    );
+    CREATE TABLE IF NOT EXISTS study_masks (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      study_item_id INTEGER NOT NULL,
+      sort_order INTEGER NOT NULL,
+      x1 REAL NOT NULL,
+      y1 REAL NOT NULL,
+      x2 REAL NOT NULL,
+      y2 REAL NOT NULL,
+      FOREIGN KEY (study_item_id) REFERENCES study_items(id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_study_items_active
+      ON study_items(deleted_at, updated_at);
+    CREATE INDEX IF NOT EXISTS idx_study_masks_item_sort
+      ON study_masks(study_item_id, sort_order);
+  `);
+
+  await migrateLegacyFlashCards(database);
+
+  return database;
+}
+
+async function migrateLegacyFlashCards(database: SQLiteDatabase) {
+  const migrationFlag = await getSecureValue(SQLITE_MIGRATION_KEY);
+  const existingItems = await database.getFirstAsync<{ count: number }>(
+    "SELECT COUNT(*) AS count FROM study_items"
+  );
+
+  if (migrationFlag === "true" || (existingItems?.count ?? 0) > 0) {
+    if (migrationFlag !== "true") {
+      await setSecureValue(SQLITE_MIGRATION_KEY, "true");
+    }
+    return;
+  }
+
+  const legacyPayload = await getSecureValue(LEGACY_FLASH_CARD_KEY);
+  if (!legacyPayload) {
+    await setSecureValue(SQLITE_MIGRATION_KEY, "true");
+    return;
+  }
+
+  let legacyItems: TImage[] = [];
+
+  try {
+    const parsed = JSON.parse(legacyPayload);
+    legacyItems = Array.isArray(parsed) ? parsed : [];
+  } catch {
+    await setSecureValue(SQLITE_MIGRATION_KEY, "true");
+    return;
+  }
+
+  await withTransaction(database, async (transaction) => {
+    for (const item of legacyItems) {
+      await upsertStudyItemRecord(transaction, item);
+    }
+  });
+
+  await deleteSecureValue(LEGACY_FLASH_CARD_KEY);
+  await setSecureValue(SQLITE_MIGRATION_KEY, "true");
+}
+
+async function withTransaction<T>(
+  database: SQLiteDatabase,
+  callback: (transaction: SQLiteDatabase) => Promise<T>
+) {
+  await database.execAsync("BEGIN");
+
+  try {
+    const result = await callback(database);
+    await database.execAsync("COMMIT");
+    return result;
+  } catch (error) {
+    await database.execAsync("ROLLBACK");
+    throw error;
+  }
+}
+
+async function upsertStudyItemRecord(database: SQLiteDatabase, item: TImage) {
+  const now = new Date().toISOString();
+
+  await database.runAsync(
+    `
+      INSERT INTO study_items (id, uri, created_at, updated_at, deleted_at)
+      VALUES (?, ?, ?, ?, NULL)
+      ON CONFLICT(id) DO UPDATE SET
+        uri = excluded.uri,
+        updated_at = excluded.updated_at,
+        deleted_at = NULL
+    `,
+    item.id,
+    item.uri,
+    now,
+    now
+  );
+
+  await database.runAsync("DELETE FROM study_masks WHERE study_item_id = ?", item.id);
+
+  for (const [index, mask] of item.masks.entries()) {
+    await database.runAsync(
+      `
+        INSERT INTO study_masks (study_item_id, sort_order, x1, y1, x2, y2)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `,
+      item.id,
+      index,
+      mask.x1,
+      mask.y1,
+      mask.x2,
+      mask.y2
+    );
+  }
+}
+
+async function getStudyItemMasks(database: SQLiteDatabase, studyItemId: number) {
+  return database.getAllAsync<StudyMaskRow>(
+    `
+      SELECT x1, y1, x2, y2
+      FROM study_masks
+      WHERE study_item_id = ?
+      ORDER BY sort_order ASC
+    `,
+    studyItemId
+  );
+}
+
+export async function initializeDatabase() {
+  return getDatabase();
+}
+
+export async function listStudyItems(): Promise<TImage[]> {
+  const database = await getDatabase();
+  const items = await database.getAllAsync<StudyItemRow>(
+    `
+      SELECT id, uri
+      FROM study_items
+      WHERE deleted_at IS NULL
+      ORDER BY created_at DESC
+    `
+  );
+
+  return Promise.all(
+    items.map(async (item) => ({
+      ...item,
+      masks: await getStudyItemMasks(database, item.id),
+    }))
+  );
+}
+
+export async function getStudyItemById(id: number) {
+  const database = await getDatabase();
+  const item = await database.getFirstAsync<StudyItemRow>(
+    `
+      SELECT id, uri
+      FROM study_items
+      WHERE id = ? AND deleted_at IS NULL
+    `,
+    id
+  );
+
+  if (!item) {
+    return null;
+  }
+
+  return {
+    ...item,
+    masks: await getStudyItemMasks(database, item.id),
+  };
+}
+
+export async function saveStudyItem(item: TImage) {
+  const database = await getDatabase();
+
+  await withTransaction(database, async (transaction) => {
+    await upsertStudyItemRecord(transaction, item);
+  });
+}
+
+export async function deleteStudyItemById(id: number) {
+  const database = await getDatabase();
+
+  await database.runAsync(
+    `
+      UPDATE study_items
+      SET deleted_at = ?, updated_at = ?
+      WHERE id = ? AND deleted_at IS NULL
+    `,
+    new Date().toISOString(),
+    new Date().toISOString(),
+    id
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "expo-router": "4.0.11",
         "expo-secure-store": "~14.0.0",
         "expo-splash-screen": "~0.29.18",
+        "expo-sqlite": "~15.1.4",
         "expo-status-bar": "~2.0.0",
         "expo-symbols": "~0.2.0",
         "expo-system-ui": "~4.0.6",
@@ -9086,6 +9087,17 @@
       },
       "peerDependencies": {
         "expo": "*"
+      }
+    },
+    "node_modules/expo-sqlite": {
+      "version": "15.1.4",
+      "resolved": "https://registry.npmjs.org/expo-sqlite/-/expo-sqlite-15.1.4.tgz",
+      "integrity": "sha512-1SG5Qi6/L2SK/o5EKtvEmlMVGdra/wYYh/intI94/ovsUfZGFrDG31YGtTt4rLpE95M6FwHUVpALO8g9/G9B2Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-status-bar": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "react-native-screens": "~4.1.0",
     "react-native-svg": "15.8.0",
     "react-native-web": "~0.19.13",
-    "react-native-webview": "13.12.5"
+    "react-native-webview": "13.12.5",
+    "expo-sqlite": "~15.1.4"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## What
- add `expo-sqlite` and initialize a local SQLite database at app startup
- add a study item repository with list/get/save/delete APIs plus one-time legacy SecureStore migration
- switch study create, list, and detail screens to the SQLite-backed repository
- document the migration decision in ADR 0009

## Why
- replace the current single-key SecureStore JSON storage, which blocks offline-first growth and future sync work
- preserve existing on-device study data while moving to the schema defined in our ADRs
- align the app with the planned `study_items` / `study_masks` data model before Cloudflare sync work begins

## Who
- existing users with locally stored study items
- future users relying on offline study data
- contributors implementing sync, entitlements, and study history on top of local storage

## When
- effective immediately after merge to `main`
- legacy SecureStore data is migrated on first launch after this build reaches a device

## Where
- startup and initialization: `app/_layout.tsx`, `app.json`
- storage layer: `constants/index.ts`, `lib/storage.ts`, `lib/study-items.ts`
- study screens: `app/(tabs)/study/create.tsx`, `app/(tabs)/study/index.tsx`, `app/(tabs)/study/[id].tsx`
- dependency/tooling: `package.json`, `package-lock.json`
- documentation: `docs/adr/0009-local-sqlite-migration.md`

## How
- Implementation: open SQLite on startup, create tables, migrate legacy SecureStore payload once, then route study screen CRUD through repository functions
- Verification: `npm run verify`
- Rollback: revert commits `4eabc06` and `5797199`